### PR TITLE
Update README.md replacing 'Chrome' with 'Chromium-based browsers'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # EthFinance Buddy
 
-This is a Chrome ~~and Firefox~~* extension to display user details for EthFinance contributors on old/new Reddit and [Kbin](https://kbin.social/m/ethfinance/).
+This is an extension for Chromium-based browsers and ~~and Firefox~~* to display user details for EthFinance contributors on old/new Reddit and [Kbin](https://kbin.social/m/ethfinance/).
 
 \* EthFinance Buddy does not currently work Firefox
 
@@ -24,7 +24,7 @@ Kbin features:
 
 1. Download this repo and move the files to your desired location.
 1. Features can be toggled on/off in the `settings.js` file. You will need to reload your extension if you change these settings after you have it installed. Change the setting to `false` to disable and `true` to enable.
-1. For Chrome:
+1. For Chromium-based browsers:
 	1. Open a new tab and enter `chrome://extensions/` into the address bar and press enter.
 	1. In the upper right turn on "Developer mode".
 	1. In the upper left select "Load unpacked".


### PR DESCRIPTION
Nothing directly against Chrome itself, but it is the least privacy-minded Chromium-based browser out there. Maybe this helps (even if in a negligible way) to reduce its control over the web browser market.